### PR TITLE
Show Completed button renders cards in correct order

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -170,13 +170,17 @@ function showCompleted(){
   let completedArray = [];
   for (let i = 0; i < taskArray.length; i++) {
     let task = taskArray[i];
+    if(!task.completed) {
+      completedArray.push(task);
+    }
+  }
+  for (let i = 0; i < taskArray.length; i++) {
+    let task = taskArray[i];
     if(task.completed) {
       completedArray.push(task);
-    } else {
-      completedArray.unshift(task);
     }
-  render(completedArray);
   }
+  render(completedArray);
 }
 
 function render(givenArray, cardsToRender) {


### PR DESCRIPTION
needed to iterate through the array twice to build the new array, first to push all the uncompleted cards and again to add the completed fuckers. this keeps the order correct and they display on page properly. huzzah!